### PR TITLE
Simplify SWR handling and reduce boilerplate code for queries and mutations

### DIFF
--- a/apps/admin-portal/src/layouts/auth-protected.tsx
+++ b/apps/admin-portal/src/layouts/auth-protected.tsx
@@ -10,16 +10,16 @@ import {
   DropdownMenuTrigger,
 } from "@peerprep/ui/dropdown-menu";
 import { Link } from "@peerprep/ui/link";
-import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { ArrowUpRight } from "lucide-react";
 import toast from "react-hot-toast";
 import { Navigate, Outlet } from "react-router-dom";
 
 import { NavLogo } from "~/components/nav-logo";
-import { mutateAuth, useAuth } from "~/lib/auth";
+import { useAuth, useLogout } from "~/lib/auth";
 
 function NavAvatar() {
   const { data: user } = useAuth();
+  const { trigger } = useLogout();
   if (!user) return null;
   return (
     <DropdownMenu>
@@ -52,13 +52,8 @@ function NavAvatar() {
           <DropdownMenuItem asChild>
             <button
               onClick={async () => {
-                try {
-                  await userClient.post("/auth/logout");
-                  await mutateAuth();
-                  toast.success("Log out successfully. See you again!");
-                } catch (e) {
-                  toast.error(getHTTPErrorMessage(e));
-                }
+                await trigger();
+                toast.success("Log out successfully. See you again!");
               }}
             >
               Log out

--- a/apps/admin-portal/src/layouts/auth-protected.tsx
+++ b/apps/admin-portal/src/layouts/auth-protected.tsx
@@ -10,17 +10,16 @@ import {
   DropdownMenuTrigger,
 } from "@peerprep/ui/dropdown-menu";
 import { Link } from "@peerprep/ui/link";
-import { getKyErrorMessage, userClient } from "@peerprep/utils/client";
+import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { ArrowUpRight } from "lucide-react";
 import toast from "react-hot-toast";
 import { Navigate, Outlet } from "react-router-dom";
-import { mutate } from "swr";
 
 import { NavLogo } from "~/components/nav-logo";
-import { SWR_KEY_USER, useUser } from "~/lib/auth";
+import { mutateAuth, useAuth } from "~/lib/auth";
 
 function NavAvatar() {
-  const { data: user } = useUser();
+  const { data: user } = useAuth();
   if (!user) return null;
   return (
     <DropdownMenu>
@@ -54,11 +53,11 @@ function NavAvatar() {
             <button
               onClick={async () => {
                 try {
-                  await userClient.post("auth/logout");
-                  await mutate(SWR_KEY_USER);
+                  await userClient.post("/auth/logout");
+                  await mutateAuth();
                   toast.success("Log out successfully. See you again!");
                 } catch (e) {
-                  toast.error(getKyErrorMessage(e));
+                  toast.error(getHTTPErrorMessage(e));
                 }
               }}
             >
@@ -73,9 +72,9 @@ function NavAvatar() {
 
 // Redirect away from this layout if the user is not authenticated
 export default function AuthProtectedLayout() {
-  const { isLoading, data: user } = useUser();
-  if (isLoading) return null;
-  if (!user) return <Navigate to="/login" />;
+  const { data: user } = useAuth();
+  if (user === undefined) return null; // loading state
+  if (user === null) return <Navigate to="/login" />;
   return (
     <div>
       <nav className="container flex flex-row justify-between py-6">

--- a/apps/admin-portal/src/layouts/public-not-auth.tsx
+++ b/apps/admin-portal/src/layouts/public-not-auth.tsx
@@ -1,13 +1,13 @@
 import { Navigate, Outlet } from "react-router-dom";
 
 import { NavLogo } from "~/components/nav-logo";
-import { useUser } from "~/lib/auth";
+import { useAuth } from "~/lib/auth";
 
 // Redirect away from this layout if the user is authenticated
 export default function PublicNotAuthLayout() {
-  const user = useUser();
-  if (user.isLoading) return null;
-  if (user.data) return <Navigate to="/" />;
+  const { data: user } = useAuth();
+  if (user === undefined) return null;
+  if (user) return <Navigate to="/" />;
   return (
     <div className="grid h-screen w-screen place-items-center">
       <nav className="container fixed inset-x-0 top-0 flex flex-row justify-between py-6">

--- a/apps/admin-portal/src/layouts/root.tsx
+++ b/apps/admin-portal/src/layouts/root.tsx
@@ -1,11 +1,14 @@
 import { Toaster } from "@peerprep/ui/toaster";
+import { getHTTPErrorMessage } from "@peerprep/utils/client";
+import toast from "react-hot-toast";
 import { Outlet } from "react-router-dom";
+import { SWRConfig } from "swr";
 
 export default function RootLayout() {
   return (
-    <div>
+    <SWRConfig value={{ onError: err => toast.error(getHTTPErrorMessage(err)) }}>
       <Outlet />
       <Toaster />
-    </div>
+    </SWRConfig>
   );
 }

--- a/apps/admin-portal/src/lib/auth.ts
+++ b/apps/admin-portal/src/lib/auth.ts
@@ -1,11 +1,32 @@
-import type { User } from "@peerprep/schemas";
+import type { NewUser, User } from "@peerprep/schemas";
 import { userClient } from "@peerprep/utils/client";
 import useSWR, { mutate } from "swr";
+import useSWRMutation from "swr/mutation";
+
+const AUTH_KEY = "user:/auth/verify-token";
 
 export function useAuth() {
-  return useSWR("user:/auth/verify-token", userClient.swrFetcher<User | null>);
+  return useSWR(AUTH_KEY, userClient.swrFetcher<User | null>);
 }
 
 export function mutateAuth() {
-  return mutate("user:/auth/verify-token");
+  return mutate(AUTH_KEY);
+}
+
+export function useLogin() {
+  return useSWRMutation(
+    AUTH_KEY,
+    (_, { arg: { email, password } }: { arg: { email: string; password: string } }) =>
+      userClient.post("/auth/login", { json: { email, password } }),
+  );
+}
+
+export function useLogout() {
+  return useSWRMutation(AUTH_KEY, () => userClient.post("/auth/logout"));
+}
+
+export function useRegister() {
+  return useSWRMutation(AUTH_KEY, (_, { arg }: { arg: NewUser }) =>
+    userClient.post("/users", { json: arg }),
+  );
 }

--- a/apps/admin-portal/src/lib/auth.ts
+++ b/apps/admin-portal/src/lib/auth.ts
@@ -1,26 +1,11 @@
 import type { User } from "@peerprep/schemas";
-import {
-  type SWRHookResult,
-  type ServiceResponseBodySuccess,
-  getKyErrorMessage,
-  userClient,
-} from "@peerprep/utils/client";
-import useSWR from "swr";
+import { userClient } from "@peerprep/utils/client";
+import useSWR, { mutate } from "swr";
 
-async function userFetcher() {
-  try {
-    const response =
-      await userClient.get<ServiceResponseBodySuccess<User | null>>("auth/verify-token");
-    const data = await response.json();
-    return data.data;
-  } catch (e) {
-    throw new Error(getKyErrorMessage(e));
-  }
+export function useAuth() {
+  return useSWR("user:/auth/verify-token", userClient.swrFetcher<User | null>);
 }
 
-export const SWR_KEY_USER = "user";
-
-export function useUser(): SWRHookResult<User | null> {
-  const { data } = useSWR(SWR_KEY_USER, userFetcher);
-  return data === undefined ? { data: undefined, isLoading: true } : { data, isLoading: false };
+export function mutateAuth() {
+  return mutate("user:/auth/verify-token");
 }

--- a/apps/admin-portal/src/routes/login.tsx
+++ b/apps/admin-portal/src/routes/login.tsx
@@ -1,14 +1,14 @@
 import { Button } from "@peerprep/ui/button";
 import { Link } from "@peerprep/ui/link";
 import { TextInput } from "@peerprep/ui/text-input";
-import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { useState } from "react";
 import toast from "react-hot-toast";
 
-import { mutateAuth } from "~/lib/auth";
+import { useLogin } from "~/lib/auth";
 
 export default function LoginPage() {
-  const [pending, setPending] = useState(false);
+  const { trigger, isMutating } = useLogin();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   return (
@@ -16,16 +16,9 @@ export default function LoginPage() {
       className="bg-main-900 flex w-full max-w-lg flex-col gap-6 p-12"
       onSubmit={async e => {
         e.preventDefault();
-        if (pending) return;
-        setPending(true);
-        try {
-          await userClient.post("/auth/login", { json: { email, password } });
-          await mutateAuth();
-          toast.success("Welcome back!");
-        } catch (e) {
-          toast.error(getHTTPErrorMessage(e));
-        }
-        setPending(false);
+        if (isMutating) return;
+        await trigger({ email, password });
+        toast.success("Welcome back!");
       }}
     >
       <h1 className="text-main-50 text-2xl">Login</h1>
@@ -47,7 +40,7 @@ export default function LoginPage() {
         value={password}
         onValueChange={setPassword}
       />
-      <Button variants={{ variant: "primary" }} type="submit">
+      <Button variants={{ variant: "primary" }} disabled={isMutating} type="submit">
         Log in
       </Button>
       <p>

--- a/apps/admin-portal/src/routes/login.tsx
+++ b/apps/admin-portal/src/routes/login.tsx
@@ -1,12 +1,11 @@
 import { Button } from "@peerprep/ui/button";
 import { Link } from "@peerprep/ui/link";
 import { TextInput } from "@peerprep/ui/text-input";
-import { getKyErrorMessage, userClient } from "@peerprep/utils/client";
+import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { mutate } from "swr";
 
-import { SWR_KEY_USER } from "~/lib/auth";
+import { mutateAuth } from "~/lib/auth";
 
 export default function LoginPage() {
   const [pending, setPending] = useState(false);
@@ -20,11 +19,11 @@ export default function LoginPage() {
         if (pending) return;
         setPending(true);
         try {
-          await userClient.post("auth/login", { json: { email, password } });
-          await mutate(SWR_KEY_USER);
+          await userClient.post("/auth/login", { json: { email, password } });
+          await mutateAuth();
           toast.success("Welcome back!");
         } catch (e) {
-          toast.error(getKyErrorMessage(e));
+          toast.error(getHTTPErrorMessage(e));
         }
         setPending(false);
       }}

--- a/apps/admin-portal/src/routes/questions.tsx
+++ b/apps/admin-portal/src/routes/questions.tsx
@@ -4,8 +4,8 @@ import { Link } from "@peerprep/ui/link";
 import { useQuestions } from "~/lib/questions";
 
 export default function QuestionsPage() {
-  const { isLoading, data: questions } = useQuestions();
-  if (isLoading) return null;
+  const { data: questions } = useQuestions();
+  if (!questions) return null;
   return (
     <div>
       Questions Page

--- a/apps/admin-portal/src/routes/register.tsx
+++ b/apps/admin-portal/src/routes/register.tsx
@@ -1,15 +1,14 @@
-import type { NewUser } from "@peerprep/schemas";
 import { Button } from "@peerprep/ui/button";
 import { Link } from "@peerprep/ui/link";
 import { TextInput } from "@peerprep/ui/text-input";
-import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { useState } from "react";
 import toast from "react-hot-toast";
 
-import { mutateAuth } from "~/lib/auth";
+import { useRegister } from "~/lib/auth";
 
 export default function RegisterPage() {
-  const [pending, setPending] = useState(false);
+  const { trigger, isMutating } = useRegister();
+
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -21,17 +20,8 @@ export default function RegisterPage() {
       className="bg-main-900 flex w-full max-w-lg flex-col gap-6 p-12"
       onSubmit={async e => {
         e.preventDefault();
-        if (pending) return;
-        setPending(true);
-        try {
-          const data: NewUser = { username, email, password, adminSignUpToken, isAdmin: true };
-          await userClient.post("/users", { json: data });
-          await mutateAuth();
-          toast.success("Admin created successfully! Please log in with the new credentials.");
-        } catch (e) {
-          toast.error(getHTTPErrorMessage(e));
-        }
-        setPending(false);
+        await trigger({ username, email, password, adminSignUpToken, isAdmin: true });
+        toast.success("Admin created successfully! Please log in with the new credentials.");
       }}
     >
       <h1 className="text-main-50 text-2xl">Register</h1>
@@ -87,7 +77,7 @@ export default function RegisterPage() {
           </>
         }
       />
-      <Button variants={{ variant: "primary" }} type="submit" disabled={pending}>
+      <Button variants={{ variant: "primary" }} type="submit" disabled={isMutating}>
         Sign up
       </Button>
       <p>

--- a/apps/admin-portal/src/routes/register.tsx
+++ b/apps/admin-portal/src/routes/register.tsx
@@ -2,12 +2,11 @@ import type { NewUser } from "@peerprep/schemas";
 import { Button } from "@peerprep/ui/button";
 import { Link } from "@peerprep/ui/link";
 import { TextInput } from "@peerprep/ui/text-input";
-import { getKyErrorMessage, userClient } from "@peerprep/utils/client";
+import { getHTTPErrorMessage, userClient } from "@peerprep/utils/client";
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { mutate } from "swr";
 
-import { SWR_KEY_USER } from "~/lib/auth";
+import { mutateAuth } from "~/lib/auth";
 
 export default function RegisterPage() {
   const [pending, setPending] = useState(false);
@@ -26,11 +25,11 @@ export default function RegisterPage() {
         setPending(true);
         try {
           const data: NewUser = { username, email, password, adminSignUpToken, isAdmin: true };
-          await userClient.post("users", { json: data });
-          await mutate(SWR_KEY_USER);
+          await userClient.post("/users", { json: data });
+          await mutateAuth();
           toast.success("Admin created successfully! Please log in with the new credentials.");
         } catch (e) {
-          toast.error(getKyErrorMessage(e));
+          toast.error(getHTTPErrorMessage(e));
         }
         setPending(false);
       }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -400,6 +400,8 @@ Examples:
   }
   ```
 
+Note that where possible, we would prefer to use `useSWR` and `useSWRMutation` from `swr` to handle queries and mutations. Please check the SWR documentation and some sample code, such as `apps/admin-portal/src/lib/auth.ts`, for more details.
+
 ## Style guide
 
 Please set up ESLint and Prettier in your code editor. If you are using VSCode, install these extensions:

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,50 +131,25 @@ Keep in mind that we use `<Link>` imported from `@peerprep/ui` instead of the `<
 
 ### Data fetching
 
-We fetch data with [SWR](https://swr.vercel.app). It is a pretty to use and lightweight library, quite similar to React Query. Please go to the link to check it out.
-
-Each type of data should have a unique key to identify it. The hook should return the type `SWRHookResult` for consistent handling throughout the codebase. Example:
+We fetch data with [SWR](https://swr.vercel.app). It is a pretty to use and lightweight library, quite similar to React Query. Please go to the link to check it out. Example:
 
 ```tsx
 import type { Question } from "@peerprep/schemas";
-import {
-  type SWRHookResult,
-  type ServiceResponseBodySuccess,
-  getKyErrorMessage,
-  questionsClient,
-} from "@peerprep/utils/client";
-import useSWR from "swr";
+import { questionsClient } from "@peerprep/utils/client";
+import useSWR, { mutate } from "swr";
 
-async function questionsFetcher() {
-  try {
-    const response = await questionsClient.get<ServiceResponseBodySuccess<Question[]>>("");
-    const data = await response.json();
-    return data.data;
-  } catch (e) {
-    throw new Error(getKyErrorMessage(e));
-  }
+export function useQuestions() {
+  return useSWR("questions:/", questionsClient.swrFetcher<Question[]>);
 }
 
-export const SWR_KEY_QUESTIONS = "questions";
-
-export function useQuestions(): SWRHookResult<Question[]> {
-  const { data } = useSWR(SWR_KEY_QUESTIONS, questionsFetcher);
-  return data === undefined ? { data: undefined, isLoading: true } : { data, isLoading: false };
+export async function mutateQuestions() {
+  return mutate("questions:/");
 }
 ```
+
+`useQuestions()` will make a request to `/` of the questions service, getting the data whose type is `Question[]`. Whenever we make changes to the questions in the backend and want to tell SWR that the data has changed, we call `mutateQuestions()`, then it will send the request again and update the state in the frontend accordingly.
 
 Thanks to SWR's [deduplication](https://swr.vercel.app/docs/advanced/performance.en-US#deduplication), we can reuse this hook anywhere we need the data in the app without having to use global state management libraries, contexts or prop drilling.
-
-Afterwards, whenever we update the data, we can then call `mutate` on the key to tell SWR to revalidate the data:
-
-```tsx
-import { mutate } from "swr";
-
-async function addQuestion() {
-  // ...
-  await mutate(SWR_KEY_QUESTIONS);
-}
-```
 
 ### Styling
 
@@ -396,43 +371,34 @@ We don't save the user's image URL (which is a [Gravatar URL](https://docs.grava
 
 The `client` "subpackage" of the `@peerprep/utils` package contains the functions shared in all frontends. **This subpackage should not be imported into the microservices (server-side).**
 
-Aside from the types `ServiceResponseBodySuccess<T>`, `ServiceResponseBodyError` and `ServiceResponseBody<T>` which are the same as described above (exported from here for use in the frontend), this subpackage exports a few more things.
+The exported clients `userClient`, `questionsClient`, etc. can be used to send requests and get data from the corresponding microservices.
 
-### `ky` stuffs
-
-Now before we continue, we should note that the frontend makes JSON requests to the microservices via [`ky`](https://github.com/sindresorhus/ky). It is a good `fetch` wrapper that simplifies things a bit for us. Please check the `ky` documentation for more details.
-
-`@peerprep/utils/client` exports `userClient`, `questionsClient`, etc. which are the `ky` instances to send requests to the corresponding microservices. It also exports `getKyErrorMessage` which can be used to extract the user-friendly error message from the backend to display in the frontend.
+If the request fails, an error will be thrown. The function `getHTTPErrorMessage` is exported for you to get a user-friendly error message from that error.
 
 Examples:
 
-- Getting data in a [SWR fetcher](https://swr.vercel.app/docs/data-fetching):
+- Getting data:
 
   ```tsx
   try {
-    const response = await questionsClient.get<ServiceResponseBodySuccess<Question[]>>("");
-    const data = await response.json();
-    return data.data;
+    const questionId = "12345";
+    const question = await questionsClient.get<Question>(`/${questionId}`);
+    console.log(question);
   } catch (e) {
-    throw new Error(getKyErrorMessage(e));
+    console.error(getHTTPErrorMessage(e));
   }
   ```
 
-- Mutating data:
+- Posting data:
 
   ```tsx
   try {
-    await userClient.post("auth/logout");
-    await mutate(SWR_KEY_USER); // We tell SWR that the user state has changed
-    toast.success("Log out successfully. See you again!");
+    await userClient.post("/auth/login", { json: { email, password } });
+    console.log("Successfully logged in");
   } catch (e) {
-    toast.error(getKyErrorMessage(e));
+    console.error(getHTTPErrorMessage(e));
   }
   ```
-
-### `SWRHookResult<T>`
-
-This type is the return type of all SWR hooks that we make to query data. See more on data fetching above.
 
 ## Style guide
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -381,10 +381,8 @@ We can use this to guard endpoints against unauthenticated requests, for example
 new Elysia()
   .use(elysiaAuthPlugin)
   .onBeforeHandle(({ user, set }) => {
-    if (!user?.isAdmin) {
-      set.status = StatusCodes.FORBIDDEN;
-      return { message: "Forbidden" };
-    }
+    if (!user?.isAdmin)
+      throw new ExpectedError("Only admins can perform this action", StatusCodes.UNAUTHORIZED);
   })
   // The user is guaranteed to be an admin now
   .get("/", () => getAllUsers());

--- a/packages/schemas/src/questions.ts
+++ b/packages/schemas/src/questions.ts
@@ -14,6 +14,10 @@ export type UpdateQuestion = Static<typeof updateSchema>;
 
 export const schema = t.Intersect([
   createSchema,
-  t.Object({ id: t.String(), createdAt: t.Optional(t.Date()), updatedAt: t.Optional(t.Date()) }),
+  t.Object({
+    id: t.String({ pattern: "^[a-f0-9]{24}$" }),
+    createdAt: t.Optional(t.Date()),
+    updatedAt: t.Optional(t.Date()),
+  }),
 ]);
 export type Question = Static<typeof schema>;

--- a/packages/schemas/src/users.ts
+++ b/packages/schemas/src/users.ts
@@ -23,7 +23,7 @@ export type UpdateUser = Static<typeof updateSchema>;
 export const schema = t.Intersect([
   baseSchema,
   t.Object({
-    id: t.String(),
+    id: t.String({ pattern: "^[a-f0-9]{24}$" }),
     password: t.Optional(t.Never()),
     createdAt: t.Date(),
     updatedAt: t.Date(),

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -39,12 +39,10 @@ function createClient(baseUrl: string) {
       // We enforce a slash here so the syntax becomes userClient.get("/users") which is more
       // readable. ky's convention enforcing ky.get("users") makes sense but is not so intuitive.
       if (!url.startsWith("/")) throw new Error("url should start with a slash for consistency");
-      console.log(url, method);
-      const response = await kyClient[method]<ServiceResponseBodySuccess<T>>(url.slice(1), {
+      const { data } = (await kyClient[method]<ServiceResponseBodySuccess<T>>(url.slice(1), {
         ...options,
         json: options?.json ?? (method === "get" || method === "head" ? undefined : {}),
-      });
-      const { data } = await response.json();
+      }).json()) as ServiceResponseBodySuccess<T>;
       return data;
     };
   }

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -1,24 +1,11 @@
 import { env } from "@peerprep/env";
-import ky, { HTTPError } from "ky";
+import ky, { HTTPError, type Options } from "ky";
 import { parse, stringify } from "superjson";
 
-import type {
-  ServiceResponseBody,
-  ServiceResponseBodyError,
-  ServiceResponseBodySuccess,
-} from "./server";
+import type { ServiceResponseBodyError, ServiceResponseBodySuccess } from "./server";
 
-export {
-  HTTPError,
-  type ServiceResponseBody,
-  type ServiceResponseBodySuccess,
-  type ServiceResponseBodyError,
-};
-
-export type SWRHookResult<T> = { data: T; isLoading: false } | { data: undefined; isLoading: true };
-
-export function getKyErrorMessage(e: unknown) {
-  return e instanceof HTTPError ? e.message : "Something went wrong. Please try again.";
+export function getHTTPErrorMessage(e: unknown) {
+  return e instanceof Error ? e.message : "Something went wrong. Please try again.";
 }
 
 async function formatKyError(error: HTTPError): Promise<HTTPError> {
@@ -30,20 +17,55 @@ async function formatKyError(error: HTTPError): Promise<HTTPError> {
   return error;
 }
 
-export const userClient = ky.create({
-  prefixUrl: `http://localhost:${env.VITE_USER_SERVICE_PORT}`,
-  credentials: "include",
-  hooks: { beforeError: [formatKyError] },
-  headers: { "Content-Type": "application/superjson" },
-  parseJson: parse,
-  stringifyJson: stringify,
-});
+function createClient(baseUrl: string) {
+  const kyClient = ky.create({
+    prefixUrl: baseUrl,
+    credentials: "include",
+    hooks: { beforeError: [formatKyError] },
+    // headers: { "Content-Type": "application/superjson" },
+    parseJson: parse,
+    stringifyJson: stringify,
+  });
 
-export const questionsClient = ky.create({
-  prefixUrl: `http://localhost:${env.VITE_QUESTION_SERVICE_PORT}`,
-  credentials: "include",
-  hooks: { beforeError: [formatKyError] },
-  headers: { "Content-Type": "application/superjson" },
-  parseJson: parse,
-  stringifyJson: stringify,
-});
+  const methods = ["get", "post", "put", "delete", "patch", "head"] as const;
+  // @ts-expect-error -- We will add the keys later
+  const client: Record<
+    (typeof methods)[number],
+    <T>(url: string, options?: Options) => Promise<T>
+  > & { swrFetcher: <T>(key: string) => Promise<T> } = {};
+
+  for (const method of methods) {
+    client[method] = async <T>(url: string, options?: Options): Promise<T> => {
+      // We enforce a slash here so the syntax becomes userClient.get("/users") which is more
+      // readable. ky's convention enforcing ky.get("users") makes sense but is not so intuitive.
+      if (!url.startsWith("/")) throw new Error("url should start with a slash for consistency");
+      console.log(url, method);
+      const response = await kyClient[method]<ServiceResponseBodySuccess<T>>(url.slice(1), {
+        ...options,
+        json: options?.json ?? (method === "get" || method === "head" ? undefined : {}),
+        headers: {
+          ...options?.headers,
+          ...(method === "get" || method === "head"
+            ? {}
+            : { "Content-Type": "application/superjson" }),
+        },
+      });
+      const { data } = await response.json();
+      return data;
+    };
+  }
+  client.swrFetcher = async <T>(key: string) => {
+    // SWR keys are global, so if we don't have the service identifier here, we could have the `/`
+    // key representing the `/` route in two different microservices. To prevent that, we mandate
+    // the use of the service identifier in the key, with a :.
+    // Example: useSWR("questions:/abc") to get the route /abc of the questions microservice.
+    if (!key.includes(":")) throw new Error("SWR key missing the service identifier");
+    const url = key.split(":")[1];
+    return client.get<T>(url);
+  };
+  return client;
+}
+
+export const userClient = createClient(`http://localhost:${env.VITE_USER_SERVICE_PORT}`);
+
+export const questionsClient = createClient(`http://localhost:${env.VITE_QUESTION_SERVICE_PORT}`);

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -22,7 +22,7 @@ function createClient(baseUrl: string) {
     prefixUrl: baseUrl,
     credentials: "include",
     hooks: { beforeError: [formatKyError] },
-    // headers: { "Content-Type": "application/superjson" },
+    headers: { "Content-Type": "application/superjson" },
     parseJson: parse,
     stringifyJson: stringify,
   });
@@ -43,12 +43,6 @@ function createClient(baseUrl: string) {
       const response = await kyClient[method]<ServiceResponseBodySuccess<T>>(url.slice(1), {
         ...options,
         json: options?.json ?? (method === "get" || method === "head" ? undefined : {}),
-        headers: {
-          ...options?.headers,
-          ...(method === "get" || method === "head"
-            ? {}
-            : { "Content-Type": "application/superjson" }),
-        },
       });
       const { data } = await response.json();
       return data;

--- a/services/questions-service/src/index.ts
+++ b/services/questions-service/src/index.ts
@@ -1,6 +1,7 @@
 import { env } from "@peerprep/env";
 import { questions } from "@peerprep/schemas/validators";
 import {
+  ExpectedError,
   elysiaAuthPlugin,
   elysiaCorsPlugin,
   elysiaFormatResponsePlugin,
@@ -18,11 +19,9 @@ import {
 
 const adminOnlyRoutes = new Elysia()
   .use(elysiaAuthPlugin)
-  .onBeforeHandle(({ user, set }) => {
-    if (!user?.isAdmin) {
-      set.status = StatusCodes.UNAUTHORIZED;
-      return { message: "Unauthorized" };
-    }
+  .onBeforeHandle(({ user }) => {
+    if (!user?.isAdmin)
+      throw new ExpectedError("Only admins can perform this action", StatusCodes.UNAUTHORIZED);
   })
   .post("/", ({ body: questions }) => createQuestions(questions), {
     body: t.Array(questions.createSchema),


### PR DESCRIPTION
## Description

Significantly simplify SWR hooks and mutation processes. for example we used to do

```ts
if (pending) return;
setPending(true);
try {
  await userClient.post("auth/login", { json: { email, password } });
  await mutate(SWR_KEY_USER);
  toast.success("Welcome back!");
} catch (e) {
  toast.error(getKyErrorMessage(e));
}
setPending(false);
```

Now we just need to do

```ts
if (isMutating) return;
await trigger({ email, password });
toast.success("Welcome back!");
```

with the help of `useSWRMutation`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Documentation update

## Screenshots (if applicable)

N/A

## Additional Notes

N/A